### PR TITLE
issues/5-invalid_mock_configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+1.1.2 (2023-04-22)
+------------------
+
+* Added missing ``user_agent`` information. See https://github.com/ColinKennedy/sphinx-code-include/issues/5
+
+
 1.1.1 (2019-10-26)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -56,9 +56,9 @@ Overview
     :alt: Supported implementations
     :target: https://pypi.org/project/sphinx-code-include
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/ColinKennedy/sphinx-code-include/v1.1.1.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/ColinKennedy/sphinx-code-include/v1.1.2.svg
     :alt: Commits since latest release
-    :target: https://github.com/ColinKennedy/sphinx-code-include/compare/v1.1.1...master
+    :target: https://github.com/ColinKennedy/sphinx-code-include/compare/v1.1.2...master
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ project = u'Sphinx Code Include'
 year = '2019'
 author = u'Colin Kennedy'
 copyright = '{0}, {1}'.format(year, author)
-version = release = u'1.1.1'
+version = release = u'1.1.2'
 
 pygments_style = 'trac'
 templates_path = ['.']

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read(*names, **kwargs):
 
 setup(
     name="sphinx-code-include",
-    version="1.1.1",
+    version="1.1.2",
     license="BSD-2-Clause",
     description="Include source code from any Sphinx project using only its import path",
     long_description="%s\n%s"

--- a/src/code_include/extension.py
+++ b/src/code_include/extension.py
@@ -13,8 +13,6 @@ from . import error_classes
 from . import formatter
 from . import source_code
 
-_SETTINGS = frontend.OptionParser().get_default_values()
-
 
 class _DocumentationHyperlink(nodes.General, nodes.Element):
     """A container that makes hyperlink text to a Python object's documentation."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -122,6 +122,7 @@ def load_cache_from_url(url):
 
         intersphinx_timeout = None  # type: int
         tls_verify = False
+        user_agent = ""
 
     class MockApplication(object):  # pylint: disable=too-few-public-methods
         """A fake state machine for intersphinx to consume and pass-through."""


### PR DESCRIPTION
Closes https://github.com/ColinKennedy/sphinx-code-include/issues/5

The code already contains "if no internet connection" skip logic. However it seems @kloczek's error pointed to missing required mock data which was only needed in the case of running outside of tox.

Reproduction
```sh
python3 -m virtualenv test
source ./test/bin/activate
pip install .
pytest -ra -m 'not network'
```

```
______________________________________________ InventoryReader.test_module ______________________________________________
tests/integrations/test_code_include.py:636: in test_module
    self._test_import(content, expected)  # pylint: disable=no-value-for-parameter
/usr/lib64/python3.6/unittest/mock.py:1183: in patched
    return func(*args, **keywargs)
tests/integrations/test_code_include.py:299: in _test_import
    _get_app_inventory.return_value = common.load_cache_from_url(path)
src/code_include/helper.py:33: in __call__
    return self[args]
src/code_include/helper.py:36: in __missing__
    ret = self[key] = self.function(*key)
tests/common.py:137: in load_cache_from_url
    return intersphinx.fetch_inventory(MockApplication(), "", url)
test/lib/python3.6/site-packages/sphinx/ext/intersphinx.py:161: in fetch_inventory
    f = _read_from_url(inv, config=app.config)
test/lib/python3.6/site-packages/sphinx/ext/intersphinx.py:117: in _read_from_url
    r = requests.get(url, stream=True, config=config, timeout=config.intersphinx_timeout)
test/lib/python3.6/site-packages/sphinx/util/requests.py:69: in get
    headers.setdefault('User-Agent', _get_user_agent(config))
test/lib/python3.6/site-packages/sphinx/util/requests.py:51: in _get_user_agent
    if config.user_agent:
E   AttributeError: ('intersphinx inventory %r not fetchable due to %s: %s', 'https://ways.readthedocs.io/en/latest/objec
ts.inv', <class 'AttributeError'>, "'MockConfiguration' object has no attribute 'user_agent'")
=================================================== warnings summary ====================================================
test/lib/python3.6/site-packages/_pytest/config/__init__.py:1196
  /home/selecaoone/repositories/sphinx-code-include/test/lib/python3.6/site-packages/_pytest/config/__init__.py:1196: Pyt
estRemovedIn8Warning: The --strict option is deprecated, use --strict-markers instead.
    _pytest.deprecated.STRICT_OPTION, stacklevel=2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================ short test summary info ================================================
FAILED tests/integrations/test_code_include.py::SourceReader::test_url - AttributeError: ('intersphinx inventory %r no...
FAILED tests/integrations/test_code_include.py::InventoryReader::test_class - AttributeError: ('intersphinx inventory ...
FAILED tests/integrations/test_code_include.py::InventoryReader::test_function - AttributeError: ('intersphinx invento...
FAILED tests/integrations/test_code_include.py::InventoryReader::test_method - AttributeError: ('intersphinx inventory...
FAILED tests/integrations/test_code_include.py::InventoryReader::test_module - AttributeError: ('intersphinx inventory...
```

However unittests pass once `user_agent` is defined

```
collected 37 items                                                                                                      

tests/integrations/test_code_include.py ......                                                                    [ 16%]
tests/unittests/test_code_include.py .................                                                            [ 62%]
tests/unittests/test_tag.py ..............                                                                        [100%]

=================================================== warnings summary ====================================================
test/lib/python3.6/site-packages/_pytest/config/__init__.py:1196
  /home/selecaoone/repositories/sphinx-code-include/test/lib/python3.6/site-packages/_pytest/config/__init__.py:1196: Pyt
estRemovedIn8Warning: The --strict option is deprecated, use --strict-markers instead.
    _pytest.deprecated.STRICT_OPTION, stacklevel=2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================= 37 passed, 1 warning in 2.35s =============================================
```